### PR TITLE
Test trusty tahr prior travis dist change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: r
 sudo: required
 cache: packages
+dist: trusty
 
 env:
   global:


### PR DESCRIPTION
Travis is moving from precise pangolin to trusty tahr for its linux images. This PR will test whether the build continues to work on tahr (it should). We don't need to merge this PR as travis will switch distributions soon by default (assuming it passes). See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming for more details.