### PR TITLE
Upgrade Rcpp to 1.0.0 (fix #87)

### DIFF
--- a/04-exemplar.Rmd
+++ b/04-exemplar.Rmd
@@ -160,11 +160,12 @@ As the code is stored on Github we can access the current master version as well
 
 Installation means the package is on our computer but it is not loaded into the computer's working memory. We also load any additional packages that might be useful for exploring the package or data therein.    
 
-```{r, echo=FALSE}
-
+```{r, eval=FALSE}
 devtools::install_github('ukgovdatascience/eesectors')
-library(eesectors)
+```
 
+```{r, echo = FALSE}
+library(eesectors)
 ```
 
 This makes all the functions within the package available for use. It also provides us with some R [data objects](https://github.com/ukgovdatascience/eesectors/tree/master/data), such as aggregated data sets ready for visualisations or analysis within the report.  

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -20,8 +20,7 @@ Hash: c0d56cd15034f395874c870141870c25
 
 Package: Rcpp
 Source: CRAN
-Version: 0.12.12
-Hash: 8b3d5ebb9a9a4ab5c86b3a81b0cfb774
+Version: 1.0.0
 
 Package: assertr
 Source: CRAN


### PR DESCRIPTION
It seems the only way to do this is to manually edit `/packrat/packrat.lock` despite packrat's documentation discouragement.